### PR TITLE
Release v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ def bar() -> None:
 The tool is still iterating. Here are some features that I plan to implement in the future:
 
 - [ ] Release control.
-- [ ] Automatic configuration file initialization.
+- [x] Automatic configuration file initialization.
 - More backends supports:
   - [ ] slack
   - [ ] email
   - [ ] feishu
-- More friendly API:
-  - [ ] Make `@monitor`/`@bake` supports additional information.
-  - [ ] Make progress signal explicitly available.
+- More friendly API.
+
+## Contribution
 
 Also, I leave some design details at [docs/docs.md](./docs/docs.md). Any suggestions and contributions are welcome!

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,5 +1,7 @@
 # Document
 
-## Arch
-
 ![](./arch_figure.png)
+
+In order to support other backends, class `ExpInfo` and class `NotifierBackend` should be inherited and implemented. (There is a special `LogInfo` class which can be regarded as a simplified version of `ExpInfo`.)
+
+The APIs needed to be (or can be) implemented are commented in the code. Follow the existing code and the comments in DingTalk backends to implement the new backend.

--- a/oven/__init__.py
+++ b/oven/__init__.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional
 from oven.oven import Oven, build_oven
 
 # Global oven.
-_lazy_oven_obj:Oven = None
+_lazy_oven_obj:Optional[Oven] = None
 def get_lazy_oven() -> Optional[Oven]:
     global _lazy_oven_obj
     if _lazy_oven_obj is None:

--- a/oven/__init__.py
+++ b/oven/__init__.py
@@ -1,16 +1,14 @@
-import sys
-from typing import Callable
+from typing import Callable, Optional
 
 from oven.oven import Oven, build_oven
-from oven.utils import (
-    dump_cfg_temp,
-    get_home_path,
-    print_manual,
-    error_redirect_to_manual,
-)
 
 # Global oven.
-oven:Oven = build_oven()
+_lazy_oven_obj:Oven = None
+def get_lazy_oven() -> Optional[Oven]:
+    global _lazy_oven_obj
+    if _lazy_oven_obj is None:
+        _lazy_oven_obj = build_oven()
+    return _lazy_oven_obj
 
 
 # =================================== #
@@ -19,7 +17,7 @@ oven:Oven = build_oven()
 
 def monitor(func) -> Callable:
     '''
-    Notifier decorator for a function. 
+    Notifier decorator for a function.
 
     Usage:
     ```
@@ -34,8 +32,7 @@ def monitor(func) -> Callable:
         ...
     ```
     '''
-    global oven
-    return oven.ding_func(func)
+    return get_lazy_oven().ding_func(func)
 
 
 def notify(msg:str) -> None:
@@ -51,47 +48,9 @@ def notify(msg:str) -> None:
     @oven.ding('Hello World!')
     ```
     '''
-    global oven
-    return oven.ding_log(msg)
+    return get_lazy_oven().ding_log(msg)
 
 
 # 🍟 Interesting alias just for fun, these alias are aligned with CLI.
 bake = monitor  # @oven.bake = @oven.monitor
 ding = notify   # oven.ding(...) = oven.notify(...)
-
-
-# =============================== #
-# CLI utils for command line use. #
-# =============================== #
-
-def cli_log() -> None:
-    ''' CLI command `ding`. '''
-    log = ' '.join(sys.argv[1:])
-    return notify(log)
-
-
-def cli_cmd() -> None:
-    ''' CLI command `bake`. '''
-    cmd = ' '.join(sys.argv[1:])
-    return oven.ding_cmd(cmd)
-
-
-def cli_full() -> None:
-    ''' CLI command `oven`. '''
-    action = sys.argv[1]
-    args = sys.argv[2:]
-
-    if action == 'help':
-        return print_manual()
-    elif action == 'ding':
-        return notify(' '.join(args))
-    elif action == 'bake':
-        return oven.ding_cmd(' '.join(args))
-    elif action == 'init-cfg':
-        return dump_cfg_temp(overwrite=False)
-    elif action == 'reset-cfg':
-        return dump_cfg_temp(overwrite=True)
-    elif action == 'home':
-        return print(get_home_path())
-    else:
-        return error_redirect_to_manual(action)

--- a/oven/backends/api/__init__.py
+++ b/oven/backends/api/__init__.py
@@ -17,7 +17,7 @@ class NotifierBackendBase:
 
 
     def __init__(self, cfg:Dict) -> None:
-        ''' Read necessary information from config file. '''
+        ''' Read necessary information from config file. And validate the configuration. '''
         pass
 
 

--- a/oven/backends/dingtalk/__init__.py
+++ b/oven/backends/dingtalk/__init__.py
@@ -10,9 +10,15 @@ from .info import DingTalkExpInfo, DingTalkLogInfo
 class DingTalkBackend(NotifierBackendBase):
 
     def __init__(self, cfg:Dict):
+        # Validate the configuration.
+        assert 'hook' in cfg and 'access_token=<?>' not in cfg['hook'], \
+            'Please ensure the validity of "dingtalk.hook" field in the configuration file!'
+        assert 'secure_key' in cfg and '<?>' not in cfg['secure_key'], \
+            'Please ensure the validity of "dingtalk.secure_key" field in the configuration file!'
+
+        # Setup.
         self.cfg = cfg
         self.url = cfg['hook']
-
 
     def notify(self, info:DingTalkExpInfo):
         '''

--- a/oven/cli.py
+++ b/oven/cli.py
@@ -1,0 +1,42 @@
+import sys
+
+def ding() -> None:
+    ''' CLI command `ding`. '''
+    import oven
+    log = ' '.join(sys.argv[1:])
+    return oven.notify(log)
+
+
+def bake() -> None:
+    ''' CLI command `bake`. '''
+    import oven
+    cmd = ' '.join(sys.argv[1:])
+    return oven.ding_cmd(cmd)
+
+
+def oven() -> None:
+    ''' CLI command `oven`. '''
+    action = sys.argv[1]
+    args = sys.argv[2:]
+
+    if action == 'help':
+        from oven.utils import print_manual
+        return print_manual()
+    elif action == 'ding':
+        import oven
+        return oven.notify(' '.join(args))
+    elif action == 'bake':
+        import oven
+        return oven.ding_cmd(' '.join(args))
+    elif action == 'init-cfg':
+        from oven.utils import dump_cfg_temp
+        return dump_cfg_temp(overwrite=False)
+    elif action == 'reset-cfg':
+        from oven.utils import dump_cfg_temp
+        return dump_cfg_temp(overwrite=True)
+    elif action == 'home':
+        from oven.utils import get_home_path
+        return print(get_home_path())
+    else:
+        from oven.utils import error_redirect_to_manual
+        return error_redirect_to_manual(action)

--- a/oven/oven.py
+++ b/oven/oven.py
@@ -114,14 +114,13 @@ def build_oven(cfg_path:Union[Path, str]=None, raise_err:bool=False) -> Oven:
     except Exception as e:
         # Generate tips.
         searched_paths = f'\n- {cfg_path}'
-        print(f'Oven configuration file not found or invalid. Searched paths: {searched_paths}')
+        print(f'Oven configuration file not found or invalid: {searched_paths}')
         print(f'You are suggested to set the environment variable `OVEN_HOME` to the directory containing the `cfg.yaml`, or ensure the validity of config files mentioned.')
+        print(f'Error: {e}')
 
-        traceback.print_exc()
         if raise_err:
+            traceback.print_exc()
             raise e
+        else:
+            exit(1)
     return oven
-
-oven = build_oven()
-
-

--- a/oven/utils.py
+++ b/oven/utils.py
@@ -3,13 +3,12 @@ import requests
 from typing import Union
 from pathlib import Path
 
-from oven.consts import cfg_temp_url, default_cfg_home
-
 def get_home_path() -> Path:
     home_path = None
     if 'OVEN_HOME' in os.environ:
         home_path = Path(os.environ['OVEN_HOME'])
     else:
+        from oven.consts import default_cfg_home
         home_path = Path(default_cfg_home)
     return home_path
 
@@ -19,6 +18,7 @@ def get_cfg_path() -> Path:
 
 
 def get_cfg_temp() -> str:
+    from oven.consts import cfg_temp_url
     return requests.get(cfg_temp_url).text
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name ='exp-oven',
-    version = '0.2',
+    version = '0.3',
     author = 'Yan XIA',
     author_email = '',
     packages = find_packages(),
@@ -22,9 +22,9 @@ setup(
     ],
     entry_points = {
         'console_scripts': [
-            'oven = oven.__init__:cli_full',  # Full version of CLI.
-            'bake = oven.__init__:cli_cmd',  # Shortcuts for baking a command.
-            'ding = oven.__init__:cli_log',  # Shortcuts for logging.
+            'oven = oven.cli:oven',  # Full version of CLI.
+            'bake = oven.cli:bake',  # Shortcuts for baking a command.
+            'ding = oven.cli:ding',  # Shortcuts for logging.
         ],
     },
 )


### PR DESCRIPTION
### Change Log

- Add simple contribution instructions.
- Move CLI functions to a separate file.
- Lazily create global oven object. Some CLI actions don't require oven object, lazily creation avoids exceptions while building oven object in that cases.