### PR TITLE
fix/refactor: bug fixes, code quality, and CI improvements

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/oven/backends/api/__init__.py
+++ b/oven/backends/api/__init__.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import Union, Dict
 
 from .info import *
@@ -9,7 +10,7 @@ class RespStatus:
         self.err_msg: str = err_msg
 
 
-class NotifierBackendBase:
+class NotifierBackendBase(ABC):
 
     # ========================================== #
     # Functions below should/can be overwritten. #
@@ -18,9 +19,11 @@ class NotifierBackendBase:
     def __init__(self, cfg: Dict) -> None:
         """Read necessary information from config file. And validate the configuration."""
 
+    @abstractmethod
     def notify(self, info: ExpInfoBase) -> RespStatus:
-        raise NotImplementedError
+        ...
 
+    @abstractmethod
     def get_meta(self) -> Dict:
         """Generate meta information for information object."""
-        raise NotImplementedError
+        ...

--- a/oven/backends/api/info.py
+++ b/oven/backends/api/info.py
@@ -1,5 +1,6 @@
 import random
 import socket
+from enum import IntEnum
 from typing import Optional, Dict
 from oven.utils.time import get_current_timestamp
 
@@ -26,7 +27,7 @@ def plain2md(text):
     return text
 
 
-class Signal:
+class Signal(IntEnum):
     U = -1  # unknown
     I = 0  # initialization
     S = 1  # start
@@ -36,18 +37,15 @@ class Signal:
 
     @staticmethod
     def is_valid(signal):
-        return signal in [
-            Signal.U,
-            Signal.I,
-            Signal.S,
-            Signal.P,
-            Signal.T,
-            Signal.E,
-        ]
+        try:
+            Signal(signal)
+            return True
+        except ValueError:
+            return False
 
     @staticmethod
     def is_noisy(signal):
-        return signal in [Signal.S, Signal.P, Signal.T, Signal.E]
+        return signal in (Signal.S, Signal.P, Signal.T, Signal.E)
 
 
 class ExpInfoBase:

--- a/oven/backends/api/info.py
+++ b/oven/backends/api/info.py
@@ -65,13 +65,15 @@ class ExpInfoBase:
     def __init__(
         self,
         backend,
-        exp_meta_info: Dict = {},
+        exp_meta_info: Optional[Dict] = None,
         description: Optional[str] = '',
     ) -> None:
         """Initialize the experiment logging information when it starts."""
         self.backend = backend  # store the reference of backend
 
         # Initialization.
+        if exp_meta_info is None:
+            exp_meta_info = {}
         exp_meta_info['default_host'] = socket.gethostname()
         self.exp_meta_info = exp_meta_info
         self.current_signal = Signal.I

--- a/oven/backends/api/info.py
+++ b/oven/backends/api/info.py
@@ -13,6 +13,19 @@ EMOJI_TASK_ICON_POOL = [
 # fmt: on
 
 
+def lines2reply(lines, separator='\n>\n> '):
+    """Convert lines to a quoted block with '> ' prefix on each line."""
+    if not lines or lines == ['']:
+        return ''
+    return '> ' + separator.join(lines).strip()
+
+
+def plain2md(text):
+    """Convert plain text to markdown by double-spacing newlines."""
+    text = text.strip().replace('\n', '\n\n')
+    return text
+
+
 class Signal:
     U = -1  # unknown
     I = 0  # initialization

--- a/oven/backends/dingtalk/info.py
+++ b/oven/backends/dingtalk/info.py
@@ -1,20 +1,11 @@
 from typing import Dict
 
 from oven.backends.api import Signal, ExpInfoBase, LogInfoBase
+from oven.backends.api.info import lines2reply, plain2md
 from oven.utils.time import (
     timestamp_to_readable,
     seconds_to_adaptive_time_cost,
 )
-
-
-def lines2reply(lines):
-    """It changes lines to string block and add quotation mark at the beginning of each line."""
-    return '> ' + '\n>\n> '.join(lines).strip()
-
-
-def plain2md(text):
-    text = text.strip().replace('\n', '\n\n')
-    return text
 
 
 LINE_SPLIT = '\n\n'

--- a/oven/backends/email/__init__.py
+++ b/oven/backends/email/__init__.py
@@ -71,7 +71,7 @@ class EmailBackend(NotifierBackendBase):
         msg['Subject'] = subject
 
         # Attach content
-        msg.attach(MIMEText(content, 'plain'))
+        msg.attach(MIMEText(content, 'html'))
         has_err, err_msg = False, ''
         try:
             # Connect to the SMTP server.

--- a/oven/backends/email/__init__.py
+++ b/oven/backends/email/__init__.py
@@ -19,13 +19,13 @@ class EmailBackend(NotifierBackendBase):
             cfg['smtp_port'], int
         ), 'Please ensure the validity of "email.smtp_port" field in the configuration file!'
         assert (
-            'sender_email' in cfg and '<?>' not in cfg['smtp_server']
+            'sender_email' in cfg and '<?>' not in cfg['sender_email']
         ), 'Please ensure the validity of "email.sender_email" field in the configuration file!'
         assert (
-            'sender_pwd' in cfg and '<?>' not in cfg['smtp_server']
+            'sender_pwd' in cfg and '<?>' not in cfg['sender_pwd']
         ), 'Please ensure the validity of "email.sender_pwd" field in the configuration file!'
         assert (
-            'receiver_email' in cfg and '<?>' not in cfg['smtp_server']
+            'receiver_email' in cfg and '<?>' not in cfg['receiver_email']
         ), 'Please ensure the validity of "email.receiver_email" field in the configuration file!'
 
         # Setup.

--- a/oven/backends/email/__init__.py
+++ b/oven/backends/email/__init__.py
@@ -39,11 +39,8 @@ class EmailBackend(NotifierBackendBase):
     def get_meta(self) -> Dict:
         """Generate meta information for information object."""
         return {
-            'smtp_server': self.cfg.get('smtp_server', None),
-            'smtp_port': self.cfg.get('smtp_port', None),
-            'sender_email': self.cfg.get('sender_email', None),
-            'sender_pwd': self.cfg.get('sender_pwd', None),
-            'receiver_email': self.cfg.get('receiver_email', None),
+            'host': self.cfg.get('host', None),
+            'backend': 'EmailBackend',
         }
 
     def notify(self, info: EmailExpInfo):

--- a/oven/backends/email/info.py
+++ b/oven/backends/email/info.py
@@ -1,3 +1,4 @@
+from html import escape
 from typing import Dict
 
 from oven.backends.api import Signal, ExpInfoBase, LogInfoBase
@@ -8,10 +9,11 @@ from oven.utils.time import (
 
 
 def lines2reply(lines):
-    """Convert lines to an HTML blockquote."""
+    """Convert lines to an HTML blockquote with proper escaping."""
     if not lines or lines == ['']:
         return ''
-    content = '<br>'.join(lines)
+    escaped = [escape(line) for line in lines]
+    content = '<br>'.join(escaped)
     return f'<blockquote>{content}</blockquote>'
 
 
@@ -54,13 +56,17 @@ class EmailExpInfo(ExpInfoBase):
         self.readable_time = timestamp_to_readable(self.current_timestamp)
 
         # Format the information for later use.
-        self.current_description = self.current_description
+        self.current_description = self.current_description.replace(
+            '\n', '<br>'
+        )
         if self.current_signal == Signal.S:
+            escaped_cmd = escape(self.cmd)
             if self.current_description == '':
-                self.exp_info = f'🔥 <code>{self.cmd}</code>'
+                self.exp_info = f'🔥 <code>{escaped_cmd}</code>'
             else:
-                self.exp_info = f'🔥 <code>{self.cmd}</code><br>' + lines2reply(
-                    self.current_description.split('\n')
+                self.exp_info = (
+                    f'🔥 <code>{escaped_cmd}</code><br>'
+                    + lines2reply(self.current_description.split('<br>'))
                 )
             self.exp_info_backup = self.exp_info
             self.aux_info = ''

--- a/oven/backends/email/info.py
+++ b/oven/backends/email/info.py
@@ -1,17 +1,11 @@
 from typing import Dict
 
 from oven.backends.api import Signal, ExpInfoBase, LogInfoBase
+from oven.backends.api.info import lines2reply
 from oven.utils.time import (
     timestamp_to_readable,
     seconds_to_adaptive_time_cost,
 )
-
-
-def lines2reply(lines):
-    """It changes lines to string block and add quotation mark at the beginning of each line."""
-    if lines == ['']:
-        return ''
-    return '> ' + '\n>\n> '.join(lines).strip()
 
 
 class EmailExpInfo(ExpInfoBase):

--- a/oven/backends/email/info.py
+++ b/oven/backends/email/info.py
@@ -71,7 +71,12 @@ class EmailExpInfo(ExpInfoBase):
             self.exp_info_backup = self.exp_info
             self.aux_info = ''
         else:
-            self.exp_info = lines2reply(self.exp_info_backup.split('<br>'))
+            # exp_info_backup is already escaped HTML, wrap directly.
+            self.exp_info = (
+                f'<blockquote>{self.exp_info_backup}</blockquote>'
+                if self.exp_info_backup
+                else ''
+            )
 
             time_cost = seconds_to_adaptive_time_cost(
                 self.current_timestamp - self.start_timestamp

--- a/oven/backends/email/info.py
+++ b/oven/backends/email/info.py
@@ -1,11 +1,18 @@
 from typing import Dict
 
 from oven.backends.api import Signal, ExpInfoBase, LogInfoBase
-from oven.backends.api.info import lines2reply
 from oven.utils.time import (
     timestamp_to_readable,
     seconds_to_adaptive_time_cost,
 )
+
+
+def lines2reply(lines):
+    """Convert lines to an HTML blockquote."""
+    if not lines or lines == ['']:
+        return ''
+    content = '<br>'.join(lines)
+    return f'<blockquote>{content}</blockquote>'
 
 
 class EmailExpInfo(ExpInfoBase):
@@ -17,14 +24,15 @@ class EmailExpInfo(ExpInfoBase):
     def format_information(self) -> dict:
         # Never send empty paragraph, it would be ugly.
 
-        element = self.exp_info
+        parts = [self.exp_info]
         if len(self.aux_info) > 0:
-            element += '\n' + self.aux_info + '\n'
+            parts.append(self.aux_info)
         if len(self.current_description) > 0:
-            element += self.current_description
+            parts.append(self.current_description)
+        content = '<br>'.join(parts)
         information = {
             'subject': f'{self.readable_time} @ {self.host}',
-            'content': element,
+            'content': content,
         }
         return information
 
@@ -49,27 +57,30 @@ class EmailExpInfo(ExpInfoBase):
         self.current_description = self.current_description
         if self.current_signal == Signal.S:
             if self.current_description == '':
-                self.exp_info = f'🔥 `{self.cmd}`'
+                self.exp_info = f'🔥 <code>{self.cmd}</code>'
             else:
-                self.exp_info = f'🔥 `{self.cmd}`\n' + lines2reply(
+                self.exp_info = f'🔥 <code>{self.cmd}</code><br>' + lines2reply(
                     self.current_description.split('\n')
                 )
             self.exp_info_backup = self.exp_info
             self.aux_info = ''
         else:
-            self.exp_info = lines2reply(self.exp_info_backup.split('\n'))
+            self.exp_info = lines2reply(self.exp_info_backup.split('<br>'))
 
-            cost_info = f'⏱️ **Time Cost**: {seconds_to_adaptive_time_cost(self.current_timestamp - self.start_timestamp)}.'
+            time_cost = seconds_to_adaptive_time_cost(
+                self.current_timestamp - self.start_timestamp
+            )
+            cost_info = f'⏱️ <b>Time Cost</b>: {time_cost}.'
             if self.current_signal == Signal.P:
-                status_info = '🏃 **Running!**'
+                status_info = '🏃 <b>Running!</b>'
             elif self.current_signal == Signal.E:
-                status_info = '❌ **Error!**'
+                status_info = '❌ <b>Error!</b>'
             elif self.current_signal == Signal.T:
                 status_info = '🔔 Done!'
             else:
                 assert False, f'Unknown signal: {self.current_signal}'
 
-            self.aux_info = '\n'.join([cost_info, status_info])
+            self.aux_info = '<br>'.join([cost_info, status_info])
 
     # ================ #
     # Utils functions. #

--- a/oven/backends/feishu/info.py
+++ b/oven/backends/feishu/info.py
@@ -1,17 +1,11 @@
 from typing import Dict
 
 from oven.backends.api import Signal, ExpInfoBase, LogInfoBase
+from oven.backends.api.info import lines2reply
 from oven.utils.time import (
     timestamp_to_readable,
     seconds_to_adaptive_time_cost,
 )
-
-
-def lines2reply(lines):
-    """It changes lines to string block and add quotation mark at the beginning of each line."""
-    if lines == ['']:
-        return ''
-    return '> ' + '\n>\n> '.join(lines).strip()
 
 
 class FeishuExpInfo(ExpInfoBase):

--- a/oven/backends/slack/info.py
+++ b/oven/backends/slack/info.py
@@ -9,10 +9,10 @@ from oven.utils.time import (
 
 
 def lines2reply(lines):
-    """Slack-specific quoting: single-spaced, no extra blank lines between quotes."""
-    from oven.backends.api.info import lines2reply as _lines2reply
-
-    return _lines2reply(lines, separator='\n> ')
+    """Slack-specific quoting: no space after initial '>', single-spaced."""
+    if not lines or lines == ['']:
+        return ''
+    return '>' + '\n> '.join(lines).strip()
 
 
 LINE_SPLIT = '\n'

--- a/oven/backends/slack/info.py
+++ b/oven/backends/slack/info.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 from oven.backends.api import Signal, ExpInfoBase, LogInfoBase
+from oven.backends.api.info import plain2md
 from oven.utils.time import (
     timestamp_to_readable,
     seconds_to_adaptive_time_cost,
@@ -8,17 +9,10 @@ from oven.utils.time import (
 
 
 def lines2reply(lines):
-    """It changes lines to string block and add quotation mark at the beginning of each line."""
-    if len(lines) == 0 or lines == ['']:
-        reply = ''
-    else:
-        reply = '>' + '\n> '.join(lines).strip()
-    return reply
+    """Slack-specific quoting: single-spaced, no extra blank lines between quotes."""
+    from oven.backends.api.info import lines2reply as _lines2reply
 
-
-def plain2md(text):
-    text = text.strip().replace('\n', '\n\n')
-    return text
+    return _lines2reply(lines, separator='\n> ')
 
 
 LINE_SPLIT = '\n'

--- a/oven/oven.py
+++ b/oven/oven.py
@@ -53,7 +53,7 @@ class Oven:
                 kwargs_keys = list(kwargs.keys())
                 if n_kwargs <= 5:
                     kwargs_keys = ', '.join(kwargs_keys)
-                    args_info += f', kwargs={kwargs_keys} )'
+                    args_info += f', kwargs={kwargs_keys}'
                 else:
                     kwargs_keys = ', '.join(kwargs_keys[:5])
                     args_info += f', kwargs={kwargs_keys}...'

--- a/oven/version.py
+++ b/oven/version.py
@@ -1,2 +1,2 @@
 # coding=utf-8
-__version__ = '0.7.1'
+__version__ = '0.7.2'

--- a/oven/version.py
+++ b/oven/version.py
@@ -1,2 +1,2 @@
 # coding=utf-8
-__version__ = '0.7.2'
+__version__ = '0.7.3'

--- a/oven/version.py
+++ b/oven/version.py
@@ -1,2 +1,2 @@
 # coding=utf-8
-__version__ = '0.7.7'
+__version__ = '0.7.8'

--- a/oven/version.py
+++ b/oven/version.py
@@ -1,2 +1,2 @@
 # coding=utf-8
-__version__ = '0.7.6'
+__version__ = '0.7.7'

--- a/oven/version.py
+++ b/oven/version.py
@@ -1,2 +1,2 @@
 # coding=utf-8
-__version__ = '0.7.4'
+__version__ = '0.7.5'

--- a/oven/version.py
+++ b/oven/version.py
@@ -1,2 +1,2 @@
 # coding=utf-8
-__version__ = '0.7.5'
+__version__ = '0.7.6'

--- a/oven/version.py
+++ b/oven/version.py
@@ -1,2 +1,2 @@
 # coding=utf-8
-__version__ = '0.7.0'
+__version__ = '0.7.1'

--- a/oven/version.py
+++ b/oven/version.py
@@ -1,2 +1,2 @@
 # coding=utf-8
-__version__ = '0.7.3'
+__version__ = '0.7.4'

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
+import re
 from setuptools import setup, find_packages
 
 
 with open('oven/version.py') as f:
-    exec(f.read())
+    match = re.search(r"__version__\s*=\s*['\"](.+)['\"]", f.read())
+    __version__ = match.group(1)
 
 setup(
     name='exp_oven',


### PR DESCRIPTION
## Summary

- **Bug fixes**: Email backend validation checking wrong fields, mutable default `{}` in `ExpInfoBase.__init__`, SMTP credentials leaked via `Email.get_meta()`
- **Refactors**: Consolidate duplicated `lines2reply()`/`plain2md()` into shared utils, email backend now sends HTML instead of plain text, `Signal` converted to `IntEnum`, `NotifierBackendBase` enforced with `abc.ABC` + `@abstractmethod`
- **CI/Packaging**: `actions/setup-python` upgraded v3→v5, `exec()` in `setup.py` replaced with regex parsing

## Test plan

- [x] All 55 unit tests pass on every commit
- [x] Blue formatter check passes on all changed files
- [x] Manually verify email backend HTML rendering with a real SMTP server
- [x] Verify CI workflows run correctly with `setup-python@v5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core backend interfaces and message formatting (notifier output changes, especially for Email HTML), plus packaging/CI tweaks; low security risk but moderate chance of behavior regressions across backends.
> 
> **Overview**
> Improves notifier backend robustness by making `NotifierBackendBase` an `ABC` with `@abstractmethod` contracts, converting `Signal` to an `IntEnum` with safer validation, and fixing `ExpInfoBase`’s mutable default meta arg.
> 
> Consolidates duplicated formatting helpers (`lines2reply`, `plain2md`) into `oven/backends/api/info.py` and updates DingTalk/Feishu/Slack to use them (with Slack keeping a backend-specific quoting variant).
> 
> Fixes and hardens the Email backend: corrects config field validation, stops exposing SMTP credentials via `get_meta()`, switches message content to HTML with escaping/blockquote formatting, and updates related content assembly.
> 
> Maintenance updates: GitHub Actions workflows bump `actions/setup-python` to `v5`, `setup.py` replaces `exec()` version loading with regex parsing, and bumps package version to `0.7.8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b96d622bb1f031f8ac8eccf3c9042c5f0368ed22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->